### PR TITLE
Update block hash format and address validation

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -262,7 +262,7 @@ impl RpcServer {
     fn rpc_latest_block(&self, _params: &[Value]) -> Result<Value> {
         Ok(json!({
             "height": 0,
-            "hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "hash": "bh_000000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": chrono::Utc::now().timestamp()
         }))
     }
@@ -278,7 +278,7 @@ impl RpcServer {
 
         Ok(json!({
             "height": _height,
-            "hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "hash": "bh_000000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": chrono::Utc::now().timestamp()
         }))
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -51,16 +51,27 @@ pub fn format_bytes(bytes: u64) -> String {
 
 /// Validate Omne address format
 pub fn validate_omne_address(address: &str) -> bool {
-    // Basic validation - should be hex string with 0x prefix and 40 characters
-    if !address.starts_with("0x") {
-        return false;
+    // Validate Omne native address format (omne1...)
+    if address.starts_with("omne1") {
+        // Should be 43 characters total (omne1 + 38 characters)
+        if address.len() != 43 {
+            return false;
+        }
+        
+        // Validate base32-like encoding (excluding 0, O, I, L)
+        const OMNE_ALPHABET: &str = "123456789abcdefghjkmnpqrstuvwxyz";
+        return address[5..].chars().all(|c| OMNE_ALPHABET.contains(c));
     }
     
-    if address.len() != 42 {
-        return false;
+    // Legacy hex address validation for backward compatibility
+    if address.starts_with("0x") {
+        if address.len() != 42 {
+            return false;
+        }
+        return address[2..].chars().all(|c| c.is_ascii_hexdigit());
     }
     
-    address[2..].chars().all(|c| c.is_ascii_hexdigit())
+    false
 }
 
 /// Generate a secure random string


### PR DESCRIPTION
Changed block hash prefix from '0x' to 'bh_' in RPC responses for consistency. Improved Omne address validation to support native 'omne1...' format with stricter checks and maintained legacy hex address compatibility.