### PR TITLE
Remove unsafe Send and Sync impls for validator structs

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -16,9 +16,9 @@ pub struct PoVERAValidator {
     state: ConsensusState,
 }
 
-// Safe to implement Send + Sync since all fields are Send + Sync
-unsafe impl Send for PoVERAValidator {}
-unsafe impl Sync for PoVERAValidator {}
+// NOTE: Removed unsafe Send + Sync implementations for security.
+// Rust will automatically implement Send + Sync if all fields are Send + Sync.
+// This prevents potential data races and undefined behavior.
 
 /// Current consensus state
 #[derive(Debug, Clone)]

--- a/src/p2p.rs
+++ b/src/p2p.rs
@@ -23,10 +23,9 @@ pub struct P2PNetwork {
     swarm: Mutex<Option<Swarm<ValidatorNetworkBehaviour>>>,
 }
 
-// Safe to implement Send + Sync since ValidatorConfig and Arc<PoVERAValidator> are Send + Sync
-// and swarm is used only in single-threaded contexts within async tasks
-unsafe impl Send for P2PNetwork {}
-unsafe impl Sync for P2PNetwork {}
+// NOTE: Removed unsafe Send + Sync implementations for security.
+// Rust will automatically implement Send + Sync if all fields are Send + Sync.
+// This prevents potential data races and undefined behavior.
 
 /// Network behaviour for validator nodes
 #[derive(NetworkBehaviour)]


### PR DESCRIPTION
Unsafe implementations of Send and Sync for PoVERAValidator and P2PNetwork have been removed. Rust will automatically derive these traits if all fields are Send + Sync, improving safety and preventing potential data races or undefined behavior.